### PR TITLE
`diary` カテゴリを `series` に統合

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -38,7 +38,7 @@ function getAllPosts(type) {
 }
 
 function getAllPostTypes() {
-  const postTypes = ["diary", "tourism", "itinerary", "series"];
+  const postTypes = ["tourism", "itinerary", "series"];
   let allPosts = [];
   for (const type of postTypes) {
     allPosts = allPosts.concat(getAllPosts(type));

--- a/src/app/(pages)/posts/Client.tsx
+++ b/src/app/(pages)/posts/Client.tsx
@@ -17,7 +17,6 @@ interface BlogClientProps {
 // 絞り込み用の選択肢
 const categories = [
   { slug: "all", title: "すべてのカテゴリー" },
-  { slug: "diary", title: "旅行日記" },
   { slug: "tourism", title: "観光情報" },
   { slug: "itinerary", title: "旅程&費用レポート" },
 ];

--- a/src/app/(pages)/posts/[slug]/page.tsx
+++ b/src/app/(pages)/posts/[slug]/page.tsx
@@ -7,7 +7,7 @@ import type { PostType } from "@/types/types";
 import { Metadata } from "next";
 import { getRelatedPosts } from "@/lib/getPostData";
 
-const categories: PostType[] = ["diary", "tourism", "itinerary", "series"];
+const categories: PostType[] = ["tourism", "itinerary", "series"];
 
 const findCategoryBySlug = async (slug: string): Promise<PostType | null> => {
   for (const category of categories) {

--- a/src/lib/dateFormat.ts
+++ b/src/lib/dateFormat.ts
@@ -2,7 +2,6 @@ import { Post } from "../types/types"; // Post型をインポート
 
 export function getDatePrefix(postType: Post["type"]): string {
   switch (postType) {
-    case "diary":
     case "itinerary":
       return "旅行日：";
     case "tourism":

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -77,16 +77,10 @@ export default function getAllPosts(type: PostType): Post[] {
 }
 
 export function getAllPostTypes(): Post[] {
-  const diaryPosts = getAllPosts("diary");
   const tourismPosts = getAllPosts("tourism");
   const itineraryPosts = getAllPosts("itinerary");
   const seriesPosts = getAllPosts("series");
-  const allPosts = [
-    ...diaryPosts,
-    ...tourismPosts,
-    ...itineraryPosts,
-    ...seriesPosts,
-  ];
+  const allPosts = [...tourismPosts, ...itineraryPosts, ...seriesPosts];
 
   return allPosts.sort((a, b) => {
     const dateA = new Date(a.dates[0]).getTime();

--- a/src/posts/series/France1.md
+++ b/src/posts/series/France1.md
@@ -6,6 +6,7 @@ image: "/images/Korea/monument.jpg"
 location: "soul, paris"
 category: "海外旅行, 一人旅"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   [
     "海外",

--- a/src/posts/series/France2.md
+++ b/src/posts/series/France2.md
@@ -6,6 +6,7 @@ image: "/images/France/louvre-museum1.jpg"
 location: "paris"
 category: "海外旅行, 一人旅"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   [
     "海外",

--- a/src/posts/series/France3.md
+++ b/src/posts/series/France3.md
@@ -6,6 +6,7 @@ image: "/images/France/chateau-de-versailles.jpg"
 location: "paris"
 category: "海外旅行, 一人旅"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   [
     "海外",

--- a/src/posts/series/Hokkaido1.md
+++ b/src/posts/series/Hokkaido1.md
@@ -6,6 +6,7 @@ image: "/images/Hokkaido/sapporo-tv-tower.jpg"
 location: "hokkaido"
 category: "国内旅行"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   [
     "日本",

--- a/src/posts/series/Hokkaido2.md
+++ b/src/posts/series/Hokkaido2.md
@@ -6,6 +6,7 @@ image: "/images/Hokkaido/susukino-crossing.jpg"
 location: "hokkaido"
 category: "国内旅行"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   [
     "日本",

--- a/src/posts/series/India1.md
+++ b/src/posts/series/India1.md
@@ -6,6 +6,7 @@ image: "/images/India/indian-gate-at-noon.jpg"
 location: "new-delhi"
 category: "海外旅行"
 author: "ともきち"
+series: 'travel-diary'
 tags: ["海外", "アジア", "インド", "ニューデリー", "世界遺産"]
 ---
 

--- a/src/posts/series/India2.md
+++ b/src/posts/series/India2.md
@@ -6,6 +6,7 @@ image: "/images/India/tajmahal.jpg"
 location: "agra, jaipur"
 category: "海外旅行"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   [
     "海外",

--- a/src/posts/series/India3.md
+++ b/src/posts/series/India3.md
@@ -6,6 +6,7 @@ image: "/images/India/amber-palace1.jpg"
 location: "jaipur"
 category: "海外旅行"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   [
     "海外",

--- a/src/posts/series/India4.md
+++ b/src/posts/series/India4.md
@@ -6,6 +6,7 @@ image: "/images/India/train-view1.jpg"
 location: "jaipur, varanasi"
 category: "海外旅行"
 author: "ともきち"
+series: 'travel-diary'
 tags: ["海外", "アジア", "インド", "バラナシ", "寝台列車", "ガンジス川", "聖地"]
 ---
 

--- a/src/posts/series/India5.md
+++ b/src/posts/series/India5.md
@@ -6,6 +6,7 @@ image: "/images/India/ganga.jpg"
 location: "varanasi"
 category: "海外旅行"
 author: "ともきち"
+series: 'travel-diary'
 tags: ["海外", "アジア", "インド", "バラナシ", "ガンジス川", "聖地", "沐浴"]
 ---
 

--- a/src/posts/series/India6.md
+++ b/src/posts/series/India6.md
@@ -6,6 +6,7 @@ image: "/images/India/varanasi-alley4.jpg"
 location: "varanasi"
 category: "海外旅行"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   ["海外", "アジア", "インド", "バラナシ", "聖地", "火葬場", "ローカルフード"]
 ---

--- a/src/posts/series/India7.md
+++ b/src/posts/series/India7.md
@@ -6,6 +6,7 @@ image: "/images/India/festival-of-ganga1.jpg"
 location: "varanasi"
 category: "海外旅行"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   ["海外", "アジア", "インド", "バラナシ", "ガンジス川", "お祭り", "インド料理"]
 ---

--- a/src/posts/series/Introduce.md
+++ b/src/posts/series/Introduce.md
@@ -6,6 +6,7 @@ image: "/images/Introduce/introduce.jpg"
 location: "kyoto"
 category: "その他"
 author: "ともきち"
+series: 'travel-diary'
 ---
 
 ## 自己紹介します

--- a/src/posts/series/Spain1.md
+++ b/src/posts/series/Spain1.md
@@ -6,6 +6,7 @@ image: "/images/Spain/casa-mira.jpg"
 location: "paris, barcelona"
 category: "海外旅行, 一人旅"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   [
     "海外",

--- a/src/posts/series/Spain2.md
+++ b/src/posts/series/Spain2.md
@@ -6,6 +6,7 @@ image: "/images/Spain/sagrada-familia.jpg"
 location: "barcelona, madrid"
 category: "海外旅行, 一人旅"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   [
     "海外",

--- a/src/posts/series/Spain3.md
+++ b/src/posts/series/Spain3.md
@@ -6,6 +6,7 @@ image: "/images/Spain/plaza-de-mayor.jpg"
 location: "madrid"
 category: "海外旅行, 一人旅"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   [
     "海外",

--- a/src/posts/series/Spain4.md
+++ b/src/posts/series/Spain4.md
@@ -6,6 +6,7 @@ image: "/images/Spain/prado-museum.jpg"
 location: "madrid"
 category: "海外旅行, 一人旅"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   [
     "海外",

--- a/src/posts/series/Spain5.md
+++ b/src/posts/series/Spain5.md
@@ -6,6 +6,7 @@ image: "/images/Spain/royal-palace-in-the-daytime.jpg"
 location: "madrid"
 category: "海外旅行, 一人旅"
 author: "ともきち"
+series: 'travel-diary'
 tags: ["海外", "スペイン", "マドリード"]
 ---
 

--- a/src/posts/series/Spain6.md
+++ b/src/posts/series/Spain6.md
@@ -6,6 +6,7 @@ image: "/images/Spain/toledo-view.jpg"
 location: "toledo"
 category: "海外旅行, 一人旅"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   [
     "海外",

--- a/src/posts/series/Spain7.md
+++ b/src/posts/series/Spain7.md
@@ -6,6 +6,7 @@ image: "/images/Belgium/galeries-royales-saint-hubert.jpg"
 location: "madrid, brussels"
 category: "海外旅行, 一人旅"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   [
     "海外",

--- a/src/posts/series/Thai1.md
+++ b/src/posts/series/Thai1.md
@@ -6,6 +6,7 @@ image: "/images/Thai/river-view-from-the-hotel-at-noon.jpg"
 location: "bangkok"
 category: "海外旅行"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   [
     "海外",

--- a/src/posts/series/Thai2.md
+++ b/src/posts/series/Thai2.md
@@ -6,6 +6,7 @@ image: "/images/Thai/wat-arun-right-up.jpg"
 location: "bangkok"
 category: "海外旅行"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   [
     "海外",

--- a/src/posts/series/Thai3.md
+++ b/src/posts/series/Thai3.md
@@ -6,6 +6,7 @@ image: "/images/Thai/wat-pho-nirvana-buddha.jpg"
 location: "bangkok"
 category: "海外旅行"
 author: "ともきち"
+series: 'travel-diary'
 tags:
   [
     "海外",

--- a/src/posts/series/Thai4.md
+++ b/src/posts/series/Thai4.md
@@ -6,6 +6,7 @@ image: "/images/Thai/do-dee-cafe.jpg"
 location: "bangkok"
 category: "海外旅行"
 author: "ともきち"
+series: 'travel-diary'
 tags: ["海外"]
 ---
 

--- a/src/posts/series/Vietnam1.md
+++ b/src/posts/series/Vietnam1.md
@@ -6,6 +6,7 @@ image: "/images/Vietnam/dong-kinh-nghia-thuc-square.jpg"
 location: "hanoi"
 category: "海外旅行"
 author: "ともきち"
+series: 'travel-diary'
 tags: ["海外", "アジア", "インド", "ベトナム", "トランジット"]
 ---
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,4 +1,4 @@
-export type PostType = "diary" | "tourism" | "itinerary" | "series";
+export type PostType = "tourism" | "itinerary" | "series";
 export interface Post {
   id: string;
   slug: string;


### PR DESCRIPTION
この変更により、ブログの投稿カテゴリ`diary`を`series`に統合します。

- `src/posts/diary` 内のすべてのマークダウンファイルを `src/posts/series` に移動しました。
- 空になった `src/posts/diary` ディレクトリを削除しました。
- `next-sitemap.config.js` と `src/lib/markdown.ts` から `diary` 投稿タイプへの参照を削除しました。
- 移動した記事のフロントマターに `series: 'travel-diary'` を追加しました。
- 型定義やコンポーネントロジックから、ハードコードされた 'diary' への参照を削除しました。