### PR TITLE
feat: Refactor related posts with region-based scoring

### DIFF
--- a/src/app/(pages)/posts/[slug]/Client.tsx
+++ b/src/app/(pages)/posts/[slug]/Client.tsx
@@ -22,7 +22,7 @@ interface ClientProps {
   post: Post;
   previousPost?: { href: string; title: string }; // 前の記事へのリンク
   nextPost?: { href: string; title: string }; // 次の記事へのリンク
-  relatedPosts?: Omit<Post, "content">[];
+  regionRelatedPosts?: Omit<Post, "content">[];
 }
 
 const Client = ({
@@ -30,7 +30,7 @@ const Client = ({
   post,
   previousPost,
   nextPost,
-  relatedPosts,
+  regionRelatedPosts,
 }: ClientProps) => {
   const [currentUrl, setCurrentUrl] = useState("");
   const [isCopied, setIsCopied] = useState(false);
@@ -140,9 +140,9 @@ const Client = ({
           </div>
 
           {/* ==================== 関連記事セクション ==================== */}
-          {relatedPosts && (
+          {regionRelatedPosts && (
             <div className="mb-10">
-              <RelatedPosts posts={relatedPosts} />
+              <RelatedPosts posts={regionRelatedPosts} />
             </div>
           )}
         </motion.footer>

--- a/src/app/(pages)/posts/[slug]/page.tsx
+++ b/src/app/(pages)/posts/[slug]/page.tsx
@@ -59,7 +59,7 @@ const PostPage = async (props: { params: Promise<{ slug: string }> }) => {
   const slug = params.slug;
 
   try {
-    const { post, previousPost, nextPost, relatedPosts, allPosts } =
+    const { post, previousPost, nextPost, regionRelatedPosts, allPosts } =
       await getPostData(slug);
 
     return (
@@ -67,7 +67,7 @@ const PostPage = async (props: { params: Promise<{ slug: string }> }) => {
         post={post}
         previousPost={previousPost}
         nextPost={nextPost}
-        relatedPosts={relatedPosts}
+        regionRelatedPosts={regionRelatedPosts}
       >
         <ArticleContent
           content={post.content}


### PR DESCRIPTION
- Renames `relatedPosts` to `regionRelatedPosts` in `posts.ts`, `page.tsx`, and `Client.tsx` for better semantic meaning.
- Implements new logic to first filter posts by the current post's region.
- Integrates `calculateScores` from `search.ts` to rank region-filtered posts.
- Sets scoring weights to prioritize tags, followed by title, excerpt, and category.
- Displays the top 3 most relevant posts based on the new scoring system.