### PR TITLE
feat: インタラクティブな世界地図コンポーネントの改修と設置

### DIFF
--- a/src/components/featured/about/AboutMeSection.tsx
+++ b/src/components/featured/about/AboutMeSection.tsx
@@ -3,8 +3,14 @@
 import Image from "next/image";
 import { motion } from "framer-motion";
 import { sectionVariants } from "@/components/animation";
+import WorldMap from "../worldMap/WorldMap";
+import { regionData } from "@/data/region";
 
 const AboutMeSection = () => {
+  // 訪問した国名を小文字の配列として抽出
+  const visitedCountryNames = regionData.flatMap((continent) =>
+    continent.countries.map((country) => country.slug)
+  );
   return (
     <motion.section
       className="py-20 md:py-28"
@@ -54,6 +60,16 @@ const AboutMeSection = () => {
               </p>
             </div>
           </div>
+        </div>
+        {/* 訪問国を可視化するマップ */}
+        <div className="mt-20">
+          <h3 className="text-2xl md:text-3xl font-bold text-center mb-10">
+            私が旅した国々
+          </h3>
+          <WorldMap
+            highlightedRegions={visitedCountryNames}
+            isClickable={false}
+          />
         </div>
       </div>
     </motion.section>

--- a/src/components/featured/worldMap/WorldMap.tsx
+++ b/src/components/featured/worldMap/WorldMap.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
 import * as d3 from "d3";
 import * as topojson from "topojson-client";
 import { Topology, GeometryCollection } from "topojson-specification";
@@ -12,22 +13,27 @@ interface WorldTopology extends Topology {
   };
 }
 
-const WorldMap = () => {
+// propsの型定義
+interface WorldMapProps {
+  highlightedRegions: string[];
+  isClickable: boolean;
+}
+
+const WorldMap: React.FC<WorldMapProps> = ({
+  highlightedRegions,
+  isClickable,
+}) => {
   const svgRef = useRef<SVGSVGElement | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
     const drawMap = async () => {
-      // このwidth/heightはviewBoxのアスペクト比と投影の計算基準として使用します
       const width = 960;
       const height = 600;
 
       const svg = d3
         .select(svgRef.current)
-        // ↓ 修正点: widthとheight属性を削除し、CSSでサイズを制御させます
-        // .attr("width", width)
-        // .attr("height", height)
         .attr("viewBox", `0 0 ${width} ${height}`)
-        // ↓ 修正点: 親要素の幅いっぱいに広がり、高さは自動調整されるようにクラスを変更
         .attr("class", "w-full h-auto mx-auto");
 
       const projection = d3
@@ -42,7 +48,6 @@ const WorldMap = () => {
 
       try {
         const world = (await d3.json("/world-110m.json")) as WorldTopology;
-
         const countries = topojson.feature(
           world,
           world.objects.countries
@@ -53,15 +58,39 @@ const WorldMap = () => {
           .selectAll("path")
           .data(countries.features)
           .join("path")
-          .attr("class", "stroke-secondary fill-muted")
-          .attr("d", pathGenerator);
+          .attr("d", pathGenerator)
+          .attr("class", (d) => {
+            const countryName = d.properties?.name.toLowerCase();
+            const isHighlighted = highlightedRegions.includes(countryName);
+
+            let classes = "stroke-secondary ";
+            if (isHighlighted) {
+              classes += "fill-primary stroke-primary-foreground";
+              if (isClickable) {
+                classes += " cursor-pointer hover:fill-primary/90";
+              }
+            } else {
+              classes += "fill-muted";
+            }
+            return classes;
+          })
+          .on("click", (event, d) => {
+            if (!isClickable) return;
+
+            const countryName = d.properties?.name.toLowerCase();
+            const isHighlighted = highlightedRegions.includes(countryName);
+
+            if (isHighlighted) {
+              router.push(`/destination/${countryName}`);
+            }
+          });
       } catch (error) {
         console.error("Error loading or drawing the map:", error);
       }
     };
 
     drawMap();
-  }, []);
+  }, [highlightedRegions, isClickable, router]);
 
   return <svg ref={svgRef} />;
 };

--- a/src/components/sections/Destination.tsx
+++ b/src/components/sections/Destination.tsx
@@ -3,8 +3,14 @@
 import { staggerContainerVariants } from "../animation";
 import WorldMap from "../featured/worldMap/WorldMap";
 import { motion } from "framer-motion";
+import { regionData } from "@/data/region";
 
 const Destination = () => {
+  // すべての国名を小文字の配列として抽出
+  const allCountryNames = regionData.flatMap((continent) =>
+    continent.countries.map((country) => country.slug)
+  );
+
   return (
     <motion.section
       initial="hidden"
@@ -13,7 +19,7 @@ const Destination = () => {
       variants={staggerContainerVariants(0.2)}
       className="py-24 px-6 md:px-8 max-w-5xl mx-auto"
     >
-      <WorldMap />
+      <WorldMap highlightedRegions={allCountryNames} isClickable={true} />
     </motion.section>
   );
 };


### PR DESCRIPTION
WorldMap.tsxコンポーネントを汎用化し、propsを通じてハイライトする国とクリック挙動を制御できるようにしました。

- `highlightedRegions`と`isClickable`のpropsを追加
- D3.jsのロジックを更新し、指定された国を動的にハイライト
- クリック可能な場合は、対応するDestinationページへ遷移する機能を追加

この汎用化されたWorldMapコンポーネントを、トップページのDestinationセクションとAboutページに設置しました。

- トップページでは、全訪問国をハイライトし、クリックでページ遷移が可能
- Aboutページでは、装飾として訪問国をハイライトし、クリックは無効化