### PR TITLE
refactor(worldmap): Separate zoom control and add reset feature

### DIFF
--- a/src/components/featured/worldMap/WorldMap.tsx
+++ b/src/components/featured/worldMap/WorldMap.tsx
@@ -46,20 +46,20 @@ const WorldMap = forwardRef<WorldMapHandle, WorldMapProps>(
     ref
   ) => {
     const svgRef = useRef<SVGSVGElement | null>(null);
+    const zoomRef = useRef<d3.ZoomBehavior<SVGSVGElement, unknown> | null>(
+      null
+    );
     const [isLoading, setIsLoading] = useState(true);
     const router = useRouter();
 
     useImperativeHandle(ref, () => ({
       resetZoom: () => {
-        if (svgRef.current) {
+        if (svgRef.current && zoomRef.current) {
           const svg = d3.select(svgRef.current);
           svg
             .transition()
             .duration(750)
-            .call(
-              d3.zoom<SVGSVGElement, unknown>().transform,
-              d3.zoomIdentity
-            );
+            .call(zoomRef.current.transform, d3.zoomIdentity);
         }
       },
     }));
@@ -175,8 +175,8 @@ const WorldMap = forwardRef<WorldMapHandle, WorldMapProps>(
               .on("zoom", (event) => {
                 g.attr("transform", event.transform.toString());
               });
-
-            svg.call(zoom);
+            zoomRef.current = zoom;
+            svg.call(zoomRef.current);
           }
 
           setIsLoading(false);

--- a/src/components/sections/Destination.tsx
+++ b/src/components/sections/Destination.tsx
@@ -1,15 +1,21 @@
 "use client";
 
+import { useRef } from "react";
 import { staggerContainerVariants } from "../animation";
-import WorldMap from "../featured/worldMap/WorldMap";
+import WorldMap, { WorldMapHandle } from "../featured/worldMap/WorldMap";
 import { motion } from "framer-motion";
 import { regionData } from "@/data/region";
 
 const Destination = () => {
+  const worldMapRef = useRef<WorldMapHandle>(null);
   // すべての国名を小文字の配列として抽出
   const allCountryNames = regionData.flatMap((continent) =>
     continent.countries.map((country) => country.slug)
   );
+
+  const handleResetZoom = () => {
+    worldMapRef.current?.resetZoom();
+  };
 
   return (
     <motion.section
@@ -25,12 +31,37 @@ const Destination = () => {
         </h2>
         <div className="w-30 h-0.5 bg-secondary mx-auto mt-6" />
       </div>
-      <WorldMap
-        highlightedRegions={allCountryNames}
-        isClickable={true}
-        isTooltip={true}
-        regionData={regionData}
-      />
+      <div className="relative">
+        <WorldMap
+          ref={worldMapRef}
+          highlightedRegions={allCountryNames}
+          isClickable={true}
+          isTooltip={true}
+          regionData={regionData}
+          isZoomable={true}
+        />
+        <button
+          onClick={handleResetZoom}
+          className="absolute bottom-4 right-4 bg-primary text-primary-foreground p-2 rounded-full shadow-lg hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+          aria-label="ズームをリセット"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="h-6 w-6"
+          >
+            <path d="m15 18-6-6 6-6" />
+            <path d="m9 18 6-6-6-6" />
+          </svg>
+        </button>
+      </div>
     </motion.section>
   );
 };


### PR DESCRIPTION
- Refactored the WorldMap component to conditionally enable zoom via an `isZoomable` prop.
- Wrapped WorldMap with `React.forwardRef` and exposed a `resetZoom` function using `useImperativeHandle`.
- Moved the responsibility for managing the zoom reset button to the parent `Destination` component.
- The `Destination` component now uses a `ref` to call the `resetZoom` function and enables zooming by passing `isZoomable={true}`.