### PR TITLE
feat: Add framer-motion animations to gallery filtering

### DIFF
--- a/src/app/(pages)/gallery/Client.tsx
+++ b/src/app/(pages)/gallery/Client.tsx
@@ -44,13 +44,6 @@ const Client = ({ posts }: ClientProps) => {
   const [activeFilter, setActiveFilter] = useState("すべて");
   const [selectedPhoto, setSelectedPhoto] = useState<Photo | null>(null);
   const [postSlug, setPostSlug] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    setIsLoading(true);
-    const timer = setTimeout(() => setIsLoading(false), 500);
-    return () => clearTimeout(timer);
-  }, [activeFilter]);
 
   useEffect(() => {
     if (selectedPhoto) {
@@ -138,11 +131,7 @@ const Client = ({ posts }: ClientProps) => {
           activeFilter={activeFilter}
           setActiveFilter={setActiveFilter}
         />
-        <PhotoGrid
-          isLoading={isLoading}
-          photos={filteredPhotos}
-          onSelectPhoto={handleSelectPhoto}
-        />
+        <PhotoGrid photos={filteredPhotos} onSelectPhoto={handleSelectPhoto} />
       </div>
 
       <PhotoModal

--- a/src/components/featured/gallery/PhotoFilter.tsx
+++ b/src/components/featured/gallery/PhotoFilter.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { motion } from "framer-motion";
 
 interface PhotoFilterProps {
   filterList: string[];
@@ -17,13 +18,20 @@ const PhotoFilter = ({
         <button
           key={filter}
           onClick={() => setActiveFilter(filter)}
-          className={`px-4 py-2 text-sm font-semibold rounded-full transition-colors duration-200 ${
-            activeFilter === filter
-              ? "bg-teal-600 text-white"
-              : "bg-gray-200 text-gray-700 hover:bg-gray-300"
+          className={`px-4 py-2 text-sm font-semibold rounded-full transition-colors duration-200 relative ${
+            activeFilter === filter ? "text-white" : "text-gray-700 hover:text-black"
           }`}
         >
-          {activeFilter === filter ? filter : filter.split("・")[0]}
+          {activeFilter === filter && (
+            <motion.div
+              layoutId="active-filter-background"
+              className="absolute inset-0 bg-teal-600 rounded-full"
+              transition={{ type: "spring", stiffness: 300, damping: 30 }}
+            />
+          )}
+          <span className="relative z-10">
+            {activeFilter === filter ? filter : filter.split("・")[0]}
+          </span>
         </button>
       ))}
     </div>

--- a/src/components/featured/gallery/PhotoGrid.tsx
+++ b/src/components/featured/gallery/PhotoGrid.tsx
@@ -1,41 +1,39 @@
 "use client";
 
 import Image from "next/image";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import { Photo } from "@/types/types";
 
 interface PhotoGridProps {
-  isLoading: boolean;
   photos: Photo[];
   onSelectPhoto: (photo: Photo) => void;
 }
 
-const PhotoGrid = ({ isLoading, photos, onSelectPhoto }: PhotoGridProps) => {
+const PhotoGrid = ({ photos, onSelectPhoto }: PhotoGridProps) => {
   return (
     <motion.div layout className="columns-2 md:columns-3 lg:columns-4 gap-4">
-      {isLoading
-        ? Array.from({ length: 12 }).map((_, i) => (
-            <div
-              key={i}
-              className="mb-4 break-inside-avoid-column bg-gray-200 animate-pulse rounded-lg w-full h-48"
+      <AnimatePresence>
+        {photos.map((photo) => (
+          <motion.div
+            layout
+            key={photo.id}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            onClick={() => onSelectPhoto(photo)}
+            className="mb-4 break-inside-avoid-column cursor-pointer group"
+          >
+            <Image
+              src={photo.image}
+              alt={photo.title}
+              width={600}
+              height={400}
+              className="rounded-lg shadow-md hover:shadow-xl transition-shadow duration-300 w-full h-auto"
             />
-          ))
-        : photos.map((photo) => (
-            <motion.div
-              layout
-              key={photo.id}
-              onClick={() => onSelectPhoto(photo)}
-              className="mb-4 break-inside-avoid-column cursor-pointer group"
-            >
-              <Image
-                src={photo.image}
-                alt={photo.title}
-                width={600}
-                height={400}
-                className="rounded-lg shadow-md hover:shadow-xl transition-shadow duration-300 w-full h-auto"
-              />
-            </motion.div>
-          ))}
+          </motion.div>
+        ))}
+      </AnimatePresence>
     </motion.div>
   );
 };


### PR DESCRIPTION
This commit introduces animations to the gallery page to enhance the user experience when filtering photos.

- Replaced the skeleton loader with a smooth cross-fade and layout animation for the photo grid using `framer-motion`'s `AnimatePresence` and `layout` props.
- Added a "magic move" animation to the active category filter button, also using `framer-motion`'s `layoutId` prop.

These changes create a more fluid and visually appealing interaction when browsing the photo gallery.