### PR TITLE
feat: Adjust zoom level and fix scroll behavior

### DIFF
--- a/src/app/(pages)/posts/Client.tsx
+++ b/src/app/(pages)/posts/Client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useEffect } from "react";
 import { motion } from "framer-motion";
 import { Post } from "@/types/types";
 import PostCard from "@/components/elements/PostCard";
@@ -60,33 +60,35 @@ const BlogClient = ({ posts, totalPages, currentPage }: BlogClientProps) => {
 
   const handleSearch = (query: string) => {
     navigate(1, categoryParam, query);
-    scrollToSearchSection();
   };
 
   const handleResetSearch = () => {
     navigate(1, categoryParam, "");
-    scrollToSearchSection();
   };
 
   const handleCategoryChange = (slug: string) => {
     navigate(1, slug, searchParam);
-    scrollToSearchSection();
   };
 
   const handlePageChange = (page: number) => {
     navigate(page, categoryParam, searchParam);
-    scrollToSearchSection();
   };
 
   const handlePrev = () => {
     navigate(Math.max(1, currentPage - 1), categoryParam, searchParam);
-    scrollToSearchSection();
   };
 
   const handleNext = () => {
     navigate(Math.min(totalPages, currentPage + 1), categoryParam, searchParam);
-    scrollToSearchSection();
   };
+
+  // searchParamsが変更された後にスクロールを実行
+  useEffect(() => {
+    // URLに何らかのクエリパラメータがある場合のみスクロール
+    if (searchParams.toString()) {
+      scrollToSearchSection();
+    }
+  }, [searchParams]);
 
   // --- ページネーション番号の生成ロジック (useMemoで不要な再計算を防ぐ) ---
   const paginationNumbers = useMemo(() => {

--- a/src/components/featured/worldMap/WorldMap.tsx
+++ b/src/components/featured/worldMap/WorldMap.tsx
@@ -68,13 +68,13 @@ const WorldMap = forwardRef<WorldMapHandle, WorldMapProps>(
       zoomIn: () => {
         if (svgRef.current && zoomRef.current) {
           const svg = d3.select(svgRef.current);
-          zoomRef.current.scaleBy(svg.transition().duration(750), 1.2);
+          zoomRef.current.scaleBy(svg.transition().duration(750), 1.5);
         }
       },
       zoomOut: () => {
         if (svgRef.current && zoomRef.current) {
           const svg = d3.select(svgRef.current);
-          zoomRef.current.scaleBy(svg.transition().duration(750), 0.8);
+          zoomRef.current.scaleBy(svg.transition().duration(750), 0.5);
         }
       },
     }));


### PR DESCRIPTION
- Increased the zoom-in factor and decreased the zoom-out factor for the world map to make the zoom more noticeable.
- Fixed an issue on the blog page where the page would scroll to the top before the search results were loaded. The scroll now happens after the content has been re-rendered.