### PR TITLE
feat: モバイルメニューの非表示ロジックと世界地図の倍率表示を更新

### DIFF
--- a/src/components/featured/worldMap/WorldMap.tsx
+++ b/src/components/featured/worldMap/WorldMap.tsx
@@ -297,7 +297,9 @@ const WorldMap = forwardRef<WorldMapHandle, WorldMapProps>(
             pointer-events-none
           "
           >
-            <p className="text-sm font-semibold">x{currentZoom.toFixed(1)}</p>
+            <p className="text-sm font-semibold">
+              ×{currentZoom.toFixed(1)}/×8.0
+            </p>
           </div>
         )}
       </div>

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -15,7 +15,11 @@ const Header = () => {
       <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="container mx-auto flex h-16 max-w-screen-2xl items-center justify-between px-4 sm:px-6 lg:px-8">
           {/* Logo */}
-          <Link href="/" className="flex items-center gap-2 max-h-16">
+          <Link
+            href="/"
+            className="flex items-center gap-2 max-h-16"
+            onClick={closeMenu}
+          >
             <span className="font-bold text-lg text-foreground font-heading">
               ともきちの旅行日記
             </span>


### PR DESCRIPTION
モバイルメニューについて、ヘッダーのロゴリンクをクリックした際にも閉じるように、onClickイベントハンドラを追加しました。

世界地図の倍率表示を、ユーザーの要求に合わせて`×1.0/×8.0`の形式に変更しました。