### PR TITLE
Fix: Link keyword and category in site search

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -6,28 +6,39 @@ import { SEARCH_CONFIG } from "@/constants/searchConfig";
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const query = searchParams.get("q");
+  const category = searchParams.get("category");
 
-  if (!query) {
+  if (!query && !category) {
     return NextResponse.json(
-      { error: "Query parameter is missing" },
-      { status: 400 }
+      { error: "Query or category parameter is missing" },
+      { status: 400 },
     );
   }
 
   try {
     const allPosts = await getAllPosts();
+    let postsToSearch = allPosts;
 
-    // 1. 検索クエリで記事をフィルタリング
-    const filteredPosts = filterPostsBySearch(allPosts, query);
+    // 1. カテゴリで絞り込み（カテゴリが指定されている場合）
+    if (category) {
+      postsToSearch = postsToSearch.filter(
+        (post) => post.category === category,
+      );
+    }
 
-    // 2. 関連度順にスコアリングしてソート
-    const scoredPosts = calculateScores(filteredPosts, query);
-    const sortedPosts = scoredPosts
-      .sort((a, b) => b.score - a.score)
-      .map((item) => item.post);
+    let finalPosts = postsToSearch;
+
+    // 2. 検索クエリでさらにフィルタリング & スコアリング（クエリがある場合）
+    if (query) {
+      const filteredBySearch = filterPostsBySearch(postsToSearch, query);
+      const scoredPosts = calculateScores(filteredBySearch, query);
+      finalPosts = scoredPosts
+        .sort((a, b) => b.score - a.score)
+        .map((item) => item.post);
+    }
 
     // 3. 上位件数を候補として返却
-    const suggestions = sortedPosts
+    const suggestions = finalPosts
       .slice(0, SEARCH_CONFIG.API_MAX_RESULTS)
       .map((post) => ({
         title: post.title,
@@ -39,7 +50,7 @@ export async function GET(request: Request) {
     console.error("Search API error:", error);
     return NextResponse.json(
       { error: "Internal Server Error" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }


### PR DESCRIPTION
Previously, the site search functionality did not correctly link the keyword search with the category filter. The search API was only considering the keyword, and the frontend hook was making separate, conflicting calls for keyword and category changes.

This commit addresses the issue by:
1.  Updating the `useSearchOverlay` hook to send both the search query and the selected category in a single API request.
2.  Modifying the `/api/search` route to accept a `category` parameter. The API now filters posts by the given category before applying the keyword search, ensuring the two filters work together as intended.