### PR TITLE
Refactor Affiliates component and create AffiliateCard

### DIFF
--- a/src/components/elements/AffiliateCard.tsx
+++ b/src/components/elements/AffiliateCard.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { AffiliatesProps } from "@/types/types";
+
+type AffiliateCardProps = {
+  affiliate: AffiliatesProps;
+  type?: "link" | "card" | "banner";
+};
+
+const AffiliateCard = ({ affiliate, type = "link" }: AffiliateCardProps) => {
+  const { affiliateUrl, name, description, icon, image, bannerHtml } =
+    affiliate;
+
+  const renderContent = () => {
+    switch (type) {
+      case "link":
+        return (
+          <Link
+            href={affiliateUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline"
+          >
+            {name}
+          </Link>
+        );
+      case "card":
+        return (
+          <Link
+            href={affiliateUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block group bg-card p-6 rounded-lg shadow-md hover:shadow-lg transition-all duration-300 ease-in-out transform hover:-translate-y-1 h-full flex flex-col items-center text-center"
+          >
+            <div className="mb-4 h-12 w-12 flex items-center justify-center">
+              {image ? (
+                <Image
+                  src={image}
+                  alt={`${name} ロゴ`}
+                  width={48}
+                  height={48}
+                  className="object-contain"
+                />
+              ) : (
+                icon
+              )}
+            </div>
+            <h3 className="text-lg font-bold text-foreground mb-2">{name}</h3>
+            <p className="text-muted-foreground flex-grow">{description}</p>
+          </Link>
+        );
+      case "banner":
+        if (!bannerHtml) return null;
+        return (
+          <div className="bg-card rounded-lg shadow-md hover:shadow-lg transition-all duration-300 ease-in-out transform hover:-translate-y-1 overflow-hidden">
+            <div
+              className="w-full"
+              dangerouslySetInnerHTML={{ __html: bannerHtml }}
+            />
+            <div className="p-4">
+              <p className="text-muted-foreground">{description}</p>
+            </div>
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return <>{renderContent()}</>;
+};
+
+export default AffiliateCard;

--- a/src/components/sections/Affiliates.tsx
+++ b/src/components/sections/Affiliates.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import Image from "next/image";
-import Link from "next/link";
 import { motion } from "framer-motion";
 import { sectionVariants, staggerContainer } from "../animation";
 import { affiliates } from "@/constants/affiliates";
+import AffiliateCard from "../elements/AffiliateCard";
 
 const Affiliates = () => {
   const appsToShow = affiliates.filter((aff) => aff.status === "ready");
@@ -37,54 +36,9 @@ const Affiliates = () => {
               whileInView="visible"
               viewport={{ once: true, amount: 0.1 }}
               variants={sectionVariants}
+              className={app.type === "banner" ? "md:col-span-2 lg:col-span-3" : ""}
             >
-              <Link
-                href={app.affiliateUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={`block group ${
-                  app.type === "banner" ? "md:col-span-2 lg:col-span-3" : "" // バナータイプは幅を広げる
-                }`}
-              >
-                {app.type === "banner" ? (
-                  // --- バナー表示 ---
-                  <div className="bg-card rounded-lg shadow-md hover:shadow-lg transition-all duration-300 ease-in-out transform hover:-translate-y-1 overflow-hidden">
-                    <Image
-                      src={app.image!}
-                      alt={`${app.name} バナー`}
-                      width={1200}
-                      height={400}
-                      className="w-full h-auto object-cover"
-                    />
-                    <div className="p-4">
-                      <p className="text-muted-foreground">{app.description}</p>
-                    </div>
-                  </div>
-                ) : (
-                  // --- カード表示 ---
-                  <div className="bg-card p-6 rounded-lg shadow-md hover:shadow-lg transition-all duration-300 ease-in-out transform hover:-translate-y-1 h-full flex flex-col items-center text-center">
-                    <div className="mb-4 h-12 w-12 flex items-center justify-center">
-                      {app.image ? (
-                        <Image
-                          src={app.image}
-                          alt={`${app.name} ロゴ`}
-                          width={48}
-                          height={48}
-                          className="object-contain"
-                        />
-                      ) : (
-                        app.icon
-                      )}
-                    </div>
-                    <h3 className="text-lg font-bold text-foreground mb-2">
-                      {app.name}
-                    </h3>
-                    <p className="text-muted-foreground flex-grow">
-                      {app.description}
-                    </p>
-                  </div>
-                )}
-              </Link>
+              <AffiliateCard affiliate={app} type={app.type} />
             </motion.div>
           ))}
         </motion.div>

--- a/src/constants/affiliates.tsx
+++ b/src/constants/affiliates.tsx
@@ -6,42 +6,43 @@ import { BedDouble, Home, Plane, Ticket, Train, Wifi } from "lucide-react";
 // affiliateUrl: アフィリエイトリンク
 // homeUrl: アフィリエイトプログラムのホームページ
 // type: 'banner' または 'card'
-// image: バナー画像 or ロゴ画像のパス
+// image: ロゴ画像のパス
 // icon: 画像がない場合のアイコン
 // description: サービスの説明
 // status: 'ready' (準備完了) or 'pending' (準備中)
+// bannerHtml: バナー表示用のHTML
 export const affiliates: AffiliatesProps[] = [
   {
     name: "Trip.com",
     affiliateUrl:
       "https://jp.trip.com/?Allianceid=7063246&SID=258431426&trip_sub1=",
     homeUrl: "https://jp.trip.com/partners/index",
-    type: "card",
-    // image: "/images/apps/tripcom-banner.png",
+    type: "banner",
     icon: <BedDouble className="w-10 h-10 text-primary" />,
     description:
       "航空券・ホテル・列車まで、旅の予約がこれ一つで完結！セールも豊富でお得に旅しよう。",
     status: "ready",
+    bannerHtml: `<a href="https://jp.trip.com/?Allianceid=7063246&SID=258431426&trip_sub1=" target="_blank" rel="noopener noreferrer"><img src="/images/Hokkaido/air-plane.jpg" alt="Trip.com Banner"/></a>`,
   },
   {
     name: "Booking.com",
     affiliateUrl: "YOUR_AFFILIATE_LINK_HERE",
     homeUrl: "YOUR_AFFILIATE_LINK_HERE",
     type: "card",
-    // image: "/images/apps/bookingcom-logo.png",
     icon: <BedDouble className="w-10 h-10 text-primary" />,
     description: "世界中のホテルや宿を網羅。豊富な口コミで安心して選べます。",
     status: "pending",
+    bannerHtml: `<a href="YOUR_AFFILIATE_LINK_HERE" target="_blank" rel="noopener noreferrer"><img src="https://via.placeholder.com/1200x400.png?text=Booking.com+Banner" alt="Booking.com Banner"/></a>`,
   },
   {
     name: "Airbnb",
     affiliateUrl: "YOUR_AFFILIATE_LINK_HERE",
     homeUrl: "YOUR_AFFILIATE_LINK_HERE",
     type: "card",
-    // image: "/images/apps/airbnb-logo.png"
     icon: <Home className="w-10 h-10 text-primary" />,
     description: "現地の人から借りるユニークな宿で、特別な宿泊体験を。",
     status: "pending",
+    bannerHtml: `<a href="YOUR_AFFILIATE_LINK_HERE" target="_blank" rel="noopener noreferrer"><img src="https://via.placeholder.com/1200x400.png?text=Airbnb+Banner" alt="Airbnb Banner"/></a>`,
   },
   {
     name: "Klook",
@@ -49,10 +50,10 @@ export const affiliates: AffiliatesProps[] = [
       "https://affiliate.klook.com/redirect?aid=99371&aff_adid=1126092&k_site=https%3A%2F%2Fwww.klook.com%2F",
     homeUrl: "https://affiliate.klook.com/ja/",
     type: "card",
-    // image: "/images/apps/klook-logo.png",
     icon: <Ticket className="w-10 h-10 text-primary" />,
     description: "遊びの予約に特化。テーマパークや現地ツアーをお得に予約。",
     status: "ready",
+    bannerHtml: `<a href="https://affiliate.klook.com/redirect?aid=99371&aff_adid=1126092&k_site=https%3A%2F%2Fwww.klook.com%2F" target="_blank" rel="noopener noreferrer"><img src="https://via.placeholder.com/1200x400.png?text=Klook+Banner" alt="Klook Banner"/></a>`,
   },
   {
     name: "GetYourGuide",
@@ -60,39 +61,39 @@ export const affiliates: AffiliatesProps[] = [
       "https://www.getyourguide.com?partner_id=GTNOM0E&utm_medium=online_publisher",
     homeUrl: "https://partner.getyourguide.com/",
     type: "card",
-    // image: "/images/apps/getyourguide-logo.png",
     icon: <Ticket className="w-10 h-10 text-primary" />,
     description: "世界中のユニークな体験ツアーが見つかる。旅の思い出作りに。",
     status: "ready",
+    bannerHtml: `<a href="https://www.getyourguide.com?partner_id=GTNOM0E&utm_medium=online_publisher" target="_blank" rel="noopener noreferrer"><img src="https://via.placeholder.com/1200x400.png?text=GetYourGuide+Banner" alt="GetYourGuide Banner"/></a>`,
   },
   {
     name: "Omio",
     affiliateUrl: "https://omio.sjv.io/MAqKX2",
     homeUrl: "https://www.omio.jp/affiliate",
     type: "card",
-    // image: "/images/apps/omio-logo.png",
     icon: <Train className="w-10 h-10 text-primary" />,
     description: "ヨーロッパの鉄道やバスをまとめて検索・予約。周遊旅行に便利。",
     status: "ready",
+    bannerHtml: `<a href="https://omio.sjv.io/MAqKX2" target="_blank" rel="noopener noreferrer"><img src="https://via.placeholder.com/1200x400.png?text=Omio+Banner" alt="Omio Banner"/></a>`,
   },
   {
     name: "SkyScanner",
     affiliateUrl: "YOUR_AFFILIATE_LINK_HERE",
     homeUrl: "YOUR_AFFILIATE_LINK_HERE",
     type: "card",
-    // image: "/images/apps/omio-logo.png",
     icon: <Plane className="w-10 h-10 text-primary" />,
     description: "世界中の航空券を一発で比較",
     status: "pending",
+    bannerHtml: `<a href="YOUR_AFFILIATE_LINK_HERE" target="_blank" rel="noopener noreferrer"><img src="https://via.placeholder.com/1200x400.png?text=SkyScanner+Banner" alt="SkyScanner Banner"/></a>`,
   },
   {
     name: "Trifa",
     affiliateUrl: "YOUR_AFFILIATE_LINK_HERE",
     homeUrl: "YOUR_AFFILIATE_LINK_HERE",
     type: "card",
-    // image: "/images/apps/trifa-logo.png
     icon: <Wifi className="w-10 h-10 text-primary" />,
     description: "eSIMで海外でもスマホを快適に。SIMの差し替え不要で楽々。",
     status: "pending",
+    bannerHtml: `<a href="YOUR_AFFILIATE_LINK_HERE" target="_blank" rel="noopener noreferrer"><img src="https://via.placeholder.com/1200x400.png?text=Trifa+Banner" alt="Trifa Banner"/></a>`,
   },
 ];

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -84,8 +84,9 @@ export interface AffiliatesProps {
   affiliateUrl: string;
   homeUrl: string;
   image?: string;
-  type: string;
+  type: "link" | "card" | "banner";
   icon?: React.ReactNode;
   description: string;
   status: string;
+  bannerHtml?: string;
 }


### PR DESCRIPTION
- Created a new `AffiliateCard` component to handle the rendering of individual affiliate links, cards, or banners.
- The `AffiliateCard` component accepts a `type` prop to control the display style ('link', 'card', 'banner').
- Updated `Affiliates.tsx` to use the new `AffiliateCard` component, simplifying the main component's logic.
- Modified `affiliates.tsx` to include `bannerHtml` for banner-style affiliates and removed commented-out code.
- Updated `types.ts` to include the `bannerHtml` property and a more specific type for affiliates.