### PR TITLE
feat: 検索結果のヒット件数を表示する機能を追加

### DIFF
--- a/dev.log
+++ b/dev.log
@@ -1,0 +1,3 @@
+
+> travelblog-test@0.1.0 dev
+> next dev

--- a/jules-scratch/verification/verify_search_counts.py
+++ b/jules-scratch/verification/verify_search_counts.py
@@ -1,0 +1,77 @@
+import re
+from playwright.sync_api import sync_playwright, expect
+
+def verify_search_functionality(page):
+    # --- 1. Verify Search Overlay ---
+    print("Navigating to homepage...")
+    page.goto("http://localhost:3000")
+
+    print("Opening search overlay...")
+    # ヘッダー内の検索ボタンをクリック
+    page.locator('header button[aria-label="検索を開く"]').click()
+
+    # オーバーレイが表示されるのを待つ
+    overlay = page.locator('div[role="dialog"], .fixed.inset-0.z-50') # Fallback selector
+    expect(overlay).to_be_visible(timeout=10000)
+    print("Search overlay is visible.")
+
+    print("Typing search query 'Spain'...")
+    search_input = overlay.get_by_placeholder("キーワードを入力...")
+    search_input.fill("Spain")
+
+    # 検索結果の件数表示を待つ
+    print("Waiting for search results count...")
+    results_count_locator = overlay.locator('text=/検索結果: .*件/')
+    expect(results_count_locator).to_be_visible(timeout=10000)
+
+    # 件数が0より大きいことを確認
+    results_text = results_count_locator.inner_text()
+    count = int(re.search(r'(\d+)', results_text).group(1))
+    assert count > 0, f"Expected search results to be greater than 0, but got {count}"
+    print(f"Search overlay count is visible: {results_text}")
+
+    # スクリーンショットを撮る
+    print("Taking screenshot of search overlay...")
+    page.screenshot(path="jules-scratch/verification/search_overlay_verification.png")
+    print("Screenshot saved to jules-scratch/verification/search_overlay_verification.png")
+
+    # オーバーレイを閉じる
+    overlay.get_by_label("検索を閉じる").click()
+    expect(overlay).not_to_be_visible()
+    print("Search overlay closed.")
+
+
+    # --- 2. Verify Posts Page ---
+    print("\nNavigating to posts page with search query...")
+    page.goto("http://localhost:3000/posts?search=Spain&category=all")
+
+    # 検索結果の件数表示を待つ
+    print("Waiting for posts page results count...")
+    posts_page_results_locator = page.locator('text=/検索結果: .*件/')
+    expect(posts_page_results_locator).to_be_visible(timeout=10000)
+
+    # 件数が0より大きいことを確認
+    posts_page_results_text = posts_page_results_locator.inner_text()
+    posts_count = int(re.search(r'(\d+)', posts_page_results_text).group(1))
+    assert posts_count > 0, f"Expected posts page results to be greater than 0, but got {posts_count}"
+    print(f"Posts page count is visible: {posts_page_results_text}")
+
+    # スクリーンショットを撮る
+    print("Taking screenshot of posts page...")
+    page.screenshot(path="jules-scratch/verification/posts_page_verification.png")
+    print("Screenshot saved to jules-scratch/verification/posts_page_verification.png")
+
+    print("\nVerification script completed successfully!")
+
+
+def main():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        try:
+            verify_search_functionality(page)
+        finally:
+            browser.close()
+
+if __name__ == "__main__":
+    main()

--- a/src/app/(pages)/posts/Client.tsx
+++ b/src/app/(pages)/posts/Client.tsx
@@ -17,12 +17,18 @@ type PostMetadata = Omit<Post, "content">;
 
 // Propsの型を定義
 interface BlogClientProps {
-  posts: PostMetadata[]; // 表示するページ分割済みの記事
-  totalPages: number; // 総ページ数
-  currentPage: number; // 現在のページ番号
+  posts: PostMetadata[];
+  totalPages: number;
+  currentPage: number;
+  totalPosts: number | null;
 }
 
-const BlogClient = ({ posts, totalPages, currentPage }: BlogClientProps) => {
+const BlogClient = ({
+  posts,
+  totalPages,
+  currentPage,
+  totalPosts,
+}: BlogClientProps) => {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -133,6 +139,15 @@ const BlogClient = ({ posts, totalPages, currentPage }: BlogClientProps) => {
             も使えます。
           </p>
         </section>
+
+        {/* ==================== Total Results ==================== */}
+        {totalPosts !== null && (
+          <section className="mb-4 text-center">
+            <p className="text-lg font-medium text-foreground">
+              検索結果: <span className="font-bold">{totalPosts}</span>件
+            </p>
+          </section>
+        )}
 
         {/* ==================== Filters ==================== */}
         <section className="mb-12">

--- a/src/app/(pages)/posts/page.tsx
+++ b/src/app/(pages)/posts/page.tsx
@@ -41,11 +41,15 @@ const PostsPage = async (props: {
     );
   }
 
-  const totalPages = Math.ceil(processedPosts.length / POSTS_PER_PAGE);
+  const totalPosts = processedPosts.length;
+  const totalPages = Math.ceil(totalPosts / POSTS_PER_PAGE);
   const paginatedPosts = processedPosts.slice(
     (page - 1) * POSTS_PER_PAGE,
-    page * POSTS_PER_PAGE
+    page * POSTS_PER_PAGE,
   );
+
+  // 検索またはカテゴリ絞り込みがある場合のみ、総件数を渡す
+  const displayTotalPosts = searchQuery || category !== "all" ? totalPosts : null;
 
   return (
     <Suspense fallback={<LoadingAnimation variant="mapRoute" />}>
@@ -53,6 +57,7 @@ const PostsPage = async (props: {
         posts={paginatedPosts}
         totalPages={totalPages}
         currentPage={page}
+        totalPosts={displayTotalPosts}
       />
     </Suspense>
   );

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -39,7 +39,8 @@ export async function GET(request: Request) {
         .map((item) => item.post);
     }
 
-    // 3. 上位件数を候補として返却
+    // 3. 結果を整形して返却
+    const total = finalPosts.length;
     const suggestions = finalPosts
       .slice(0, SEARCH_CONFIG.API_MAX_RESULTS)
       .map((post) => ({
@@ -47,7 +48,10 @@ export async function GET(request: Request) {
         slug: post.slug,
       }));
 
-    return NextResponse.json(suggestions);
+    return NextResponse.json({
+      suggestions,
+      total,
+    });
   } catch (error) {
     console.error("Search API error:", error);
     return NextResponse.json(

--- a/src/components/featured/search/SearchOverlay.tsx
+++ b/src/components/featured/search/SearchOverlay.tsx
@@ -83,13 +83,15 @@ const SearchSuggestions = ({
   selectedCategory,
   executeSearch,
   onClose,
+  totalResults,
 }: {
-  searchTerm: string;
+  searchTerm:string;
   suggestions: Suggestion[];
   isLoading: boolean;
   selectedCategory: string | null;
   executeSearch: () => void;
   onClose: () => void;
+  totalResults: number | null;
 }) => {
   // カテゴリ選択時もサジェストを表示するため、selectedCategoryも条件に含める
   const canShowComponent =
@@ -97,7 +99,7 @@ const SearchSuggestions = ({
 
   const displayedSuggestions = suggestions.slice(
     0,
-    SEARCH_CONFIG.MAX_SUGGESTIONS
+    SEARCH_CONFIG.MAX_SUGGESTIONS,
   );
 
   const showSeeAllButton = suggestions.length > SEARCH_CONFIG.MAX_SUGGESTIONS;
@@ -122,6 +124,12 @@ const SearchSuggestions = ({
   return (
     <div className="mt-4 bg-background border border-border rounded-lg shadow-lg">
       {isLoading && <LoadingAnimation variant="luggageCarousel" />}
+
+      {!isLoading && totalResults !== null && (
+        <div className="p-3 text-sm text-muted-foreground border-b border-border">
+          検索結果: {totalResults}件
+        </div>
+      )}
 
       {!isLoading && displayedSuggestions.length > 0 && (
         <motion.ul
@@ -153,7 +161,8 @@ const SearchSuggestions = ({
 
       {!isLoading &&
         suggestions.length === 0 &&
-        (searchTerm || selectedCategory) && (
+        (searchTerm || selectedCategory) &&
+        totalResults === 0 && (
           <div className="p-4 text-muted-foreground">
             一致する記事は見つかりませんでした。
             <br />
@@ -174,6 +183,7 @@ const SearchOverlay = ({ isOpen, onClose }: SearchOverlayProps) => {
     selectedCategory,
     toggleCategory,
     suggestions,
+    totalResults,
     isLoading,
     executeSearch,
     handleKeyDown,
@@ -248,6 +258,7 @@ const SearchOverlay = ({ isOpen, onClose }: SearchOverlayProps) => {
               selectedCategory={selectedCategory}
               executeSearch={executeSearch}
               onClose={onClose}
+              totalResults={totalResults}
             />
           </motion.div>
         </motion.div>


### PR DESCRIPTION
ユーザーがキーワードやカテゴリで検索した際に、ヒットした記事の件数を表示する機能を追加します。

主な変更点:
- `/api/search` APIのレスポンスに、検索結果のリスト(`suggestions`)に加えて、総件数(`total`)も含まれるようにしました。
- 検索オーバーレイで、検索実行後に「検索結果：〇件」という形式でヒット数を表示するようにしました。
- 記事一覧ページでも、検索やカテゴリでの絞り込みが行われた際に、結果の総数を表示するようにしました。