### PR TITLE
fix(netlify): Resolve MissingBlobsEnvironmentError

### DIFF
--- a/netlify/functions/ai-planner-background.ts
+++ b/netlify/functions/ai-planner-background.ts
@@ -116,7 +116,11 @@ const handler: Handler = async (event: HandlerEvent, context: HandlerContext) =>
     };
   }
 
-  const store = getStore("ai-planner-jobs");
+  const store = getStore({
+    name: "ai-planner-jobs",
+    siteID: process.env.SITE_ID,
+    token: process.env.NETLIFY_API_TOKEN,
+  });
 
   try {
     const jobData = (await store.get(jobId, { type: "json" })) as JobData;


### PR DESCRIPTION
The ai-planner-background function was failing with a `MissingBlobsEnvironmentError`. This occurred because the `@netlify/blobs` library was unable to automatically resolve the necessary environment context.

This commit fixes the issue by explicitly passing `siteID` and `token` to the `getStore` function. The values are sourced from the standard Netlify environment variables `process.env.SITE_ID` and `process.env.NETLIFY_API_TOKEN`, ensuring the function connects to Netlify Blobs correctly.