### PR TITLE
Update Footer and Sitemap Links

### DIFF
--- a/src/app/(pages)/sitemap/page.tsx
+++ b/src/app/(pages)/sitemap/page.tsx
@@ -7,7 +7,7 @@ import HeroSection from "@/components/pages/HeroSection";
 import { featuredSeries } from "@/data/series";
 import { regionData } from "@/data/region";
 import AllDestination from "@/components/features/destination/allDestination";
-import { AI_PLANNER_PATH, MAP_PATH, SITE_STATUS_PATH } from "@/constants/site";
+import { MAP_PATH } from "@/constants/site";
 
 export const metadata: Metadata = {
   title: "サイトマップ",
@@ -54,7 +54,6 @@ const mainList = [
   { pass: "/destination", name: "地域別" },
   { pass: "/gallery", name: "写真ギャラリー" },
   { pass: "/social", name: "SNSページ" },
-  { pass: AI_PLANNER_PATH, name: "AI旅行プランナー" },
   { pass: "/faq", name: "FAQ" },
   { pass: "/request", name: "記事テーマ募集ページ" },
   { pass: "/contact", name: "お問い合わせページ" },
@@ -65,7 +64,6 @@ const mainList = [
   { pass: "/journey", name: "旅の軌跡" },
   { pass: "/roadmap", name: "ロードマップ" },
   { pass: MAP_PATH, name: "Tomokichi Globe" },
-  { pass: SITE_STATUS_PATH, name: "サイトステータス" },
 ];
 
 // --- Page Component ---

--- a/src/constants/navigation.tsx
+++ b/src/constants/navigation.tsx
@@ -1,5 +1,5 @@
 import { FaGithub, FaPenSquare, FaTiktok, FaYoutube } from "react-icons/fa";
-import { AI_PLANNER_PATH, MAP_PATH, SITE_STATUS_PATH } from "./site";
+import { AI_PLANNER_PATH, MAP_PATH } from "./site";
 
 export interface NavLink {
   href: string;
@@ -25,6 +25,7 @@ export const NAV_LINKS: NavLink[] = [
 
 export const FOOTER_CONTENTS_LIST: FooterContent[] = [
   { name: "旅の軌跡", pass: "/journey" },
+  { name: "Tomokichi Globe", pass: MAP_PATH },
   { name: "地域別一覧", pass: "/destination" },
   { name: "シリーズ一覧", pass: "/series" },
   { name: "ブログ一覧", pass: "/posts" },
@@ -34,10 +35,6 @@ export const FOOTER_CONTENTS_LIST: FooterContent[] = [
 export const FOOTER_ABOUT_LIST: FooterContent[] = [
   { name: "サイトについて", pass: "/about" },
   { name: "更新情報・ロードマップ", pass: "/roadmap" },
-  {
-    name: "サイトステータス",
-    pass: SITE_STATUS_PATH,
-  },
   { name: "サイトマップ", pass: "/sitemap" },
 ];
 


### PR DESCRIPTION
Updates footer links to include Tomokichi Globe and removes site status. Also removes site status and AI planner links from the sitemap.

---
*PR created automatically by Jules for task [8111060525527118110](https://jules.google.com/task/8111060525527118110) started by @tomoki013*