### PR TITLE
perf: 日本語フォント最適化・レガシーJS削除・preconnect追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,14 @@
     "check": "pnpm lint && pnpm typecheck && pnpm format:check",
     "ci": "pnpm prebuild && pnpm check && pnpm build"
   },
+  "browserslist": [
+    "chrome >= 96",
+    "edge >= 96",
+    "firefox >= 96",
+    "safari >= 15.4",
+    "ios_saf >= 15.4",
+    "not dead"
+  ],
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",
     "@radix-ui/react-accordion": "^1.2.12",

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { Caveat, Montserrat, Playfair_Display, Noto_Sans_JP } from "next/font/google";
+import {
+  Caveat,
+  Montserrat,
+  Playfair_Display,
+  Noto_Sans_JP,
+  Shippori_Mincho,
+} from "next/font/google";
 import "./globals.css";
 import { useEffect } from "react";
 import ErrorDisplay from "@/components/common/ErrorDisplay";
@@ -27,6 +33,16 @@ const notoSansJp = Noto_Sans_JP({
   subsets: ["latin"],
   weight: ["400", "500", "700"],
   variable: "--font-noto-sans-jp",
+  display: "swap",
+  preload: false,
+});
+
+const shipporiMincho = Shippori_Mincho({
+  subsets: ["latin"],
+  weight: ["500", "700"],
+  variable: "--font-shippori-mincho",
+  display: "swap",
+  preload: false,
 });
 
 export default function GlobalError({
@@ -43,7 +59,7 @@ export default function GlobalError({
   return (
     <html lang="ja">
       <body
-        className={`${montserrat.variable} ${playfairDisplay.variable} ${caveat.variable} ${notoSansJp.variable} antialiased`}
+        className={`${montserrat.variable} ${playfairDisplay.variable} ${caveat.variable} ${notoSansJp.variable} ${shipporiMincho.variable} antialiased`}
       >
         <ErrorDisplay reset={reset} />
       </body>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -49,19 +49,6 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
-  --color-chart-1: var(--chart-1);
-  --color-chart-2: var(--chart-2);
-  --color-chart-3: var(--chart-3);
-  --color-chart-4: var(--chart-4);
-  --color-chart-5: var(--chart-5);
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
 }
 
 :root {
@@ -102,16 +89,6 @@
   --chart-3: oklch(0.55 0.15 250);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-
-  /* サイドバー */
-  --sidebar: oklch(0.99 0.005 89.53); /* backgroundより少し明るい */
-  --sidebar-foreground: var(--foreground);
-  --sidebar-primary: var(--primary);
-  --sidebar-primary-foreground: var(--primary-foreground);
-  --sidebar-accent: oklch(0.95 0.018 89.53);
-  --sidebar-accent-foreground: var(--primary);
-  --sidebar-border: var(--border);
-  --sidebar-ring: var(--ring);
 }
 
 .dark {
@@ -150,20 +127,10 @@
   --chart-3: oklch(0.65 0.15 250);
   --chart-4: oklch(0.85 0.18 84.429);
   --chart-5: oklch(0.8 0.18 70.08);
-
-  /* サイドバー (ダークモード) */
-  --sidebar: oklch(0.15 0.01 89.53); /* 背景よりさらに暗い */
-  --sidebar-foreground: var(--foreground);
-  --sidebar-primary: var(--primary);
-  --sidebar-primary-foreground: var(--primary-foreground);
-  --sidebar-accent: oklch(0.28 0.03 89.53);
-  --sidebar-accent-foreground: var(--primary);
-  --sidebar-border: var(--border);
-  --sidebar-ring: var(--ring);
 }
 
 .font-heading {
-  font-family: var(--font-playfair-display), serif;
+  font-family: var(--font-playfair-display), var(--font-shippori-mincho), serif;
 }
 .font-code {
   font-family: var(--font-caveat), cursive;
@@ -181,6 +148,7 @@ html {
 body {
   font-family:
     var(--font-montserrat),
+    var(--font-noto-sans-jp),
     system-ui,
     -apple-system,
     BlinkMacSystemFont,
@@ -188,7 +156,6 @@ body {
     Roboto,
     "Helvetica Neue",
     Arial,
-    var(--font-noto-sans-jp),
     sans-serif;
   background-color: var(--background);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,11 @@
 import type { Metadata, Viewport } from "next";
-import { Caveat, Montserrat, Playfair_Display, Noto_Sans_JP } from "next/font/google";
+import {
+  Caveat,
+  Montserrat,
+  Playfair_Display,
+  Noto_Sans_JP,
+  Shippori_Mincho,
+} from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/components/common/theme-provider";
 import Header from "@/components/layouts/Header";
@@ -37,6 +43,21 @@ const notoSansJp = Noto_Sans_JP({
   weight: ["400", "700"],
   variable: "--font-noto-sans-jp",
   display: "swap",
+  // メインの日本語フォント。約40分割スライスを critical path で
+  // 一斉プリロードすると帯域を食い潰し LCP を阻害するため preload は無効化し、
+  // display: "swap" でフォールバック即時描画 → 到着後に差し替える。
+  preload: false,
+});
+
+// 見出し用の日本語明朝。欧文 Playfair Display と組み合わせ、日本語見出しを
+// 全環境で同一の明朝体に統一する。本文同様、約40分割スライスの一斉プリロードを
+// 避けるため preload は無効化し display: "swap" で描画後に差し替える。
+const shipporiMincho = Shippori_Mincho({
+  subsets: ["latin"],
+  weight: ["500", "700"],
+  variable: "--font-shippori-mincho",
+  display: "swap",
+  preload: false,
 });
 
 export const metadata: Metadata = {
@@ -102,8 +123,15 @@ export default function RootLayout({
   return (
     <html lang="ja" suppressHydrationWarning>
       <body
-        className={`${montserrat.variable} ${playfairDisplay.variable} ${caveat.variable} ${notoSansJp.variable} antialiased`}
+        className={`${montserrat.variable} ${playfairDisplay.variable} ${caveat.variable} ${notoSansJp.variable} ${shipporiMincho.variable} antialiased`}
       >
+        {/* 第三者ドメインへの事前接続（React 19 が <head> へホイストする）。
+            フォントは自己ホスト＝同一オリジンのため preconnect 不要。 */}
+        <link rel="preconnect" href="https://www.googletagmanager.com" />
+        <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
+        <link rel="preconnect" href="https://widget.getyourguide.com" />
+        <link rel="dns-prefetch" href="https://www.google-analytics.com" />
+
         {/* GetYourGuide Analytics */}
         <Script
           async


### PR DESCRIPTION
## 概要

PageSpeed Insights のボトルネック分析にもとづくパフォーマンス改善。最大の原因だった**日本語フォントの大量プリロード**を解消し、レガシーJSポリフィルを除去、第三者ドメインへの preconnect を追加した。

## 変更内容

### フォント（最大の効果）
- `Noto_Sans_JP` をメインの日本語本文フォントに昇格し、見出し用に `Shippori_Mincho`（明朝）を追加。
- 両CJKフォントに `preload: false` + `display: "swap"` を設定。約40本の unicode-range 分割スライスが critical path を専有してCSS到着を遅らせ、**LCP要素レンダリング遅延 ~4.5s** を生んでいたのを解消。
- **フォントの preload リンク数：約40本 → 3本**（ラテン表示フォントのみ）に削減（実測確認済み）。
- デザイン方針：**見出し＝明朝（Shippori、全環境統一）／本文＝ゴシック（Noto）**。

### レガシーJSポリフィル除去
- モダンブラウザを対象とする `browserslist` を追加。`Array.prototype.at/flat`, `Object.hasOwn`, `String.prototype.trim*` などのポリフィルチャンクが**ビルド成果物から消滅**（実測確認済み）。

### preconnect / dns-prefetch
- `googletagmanager.com` / `google-analytics.com` / `widget.getyourguide.com` への事前接続ヒントを追加（元PSIで「事前接続オリジンなし」と指摘）。

### デッドCSS削除
- 未使用の shadcn `--sidebar-*` 変数と `--color-chart-*` テーマトークンを `globals.css` から除去。挙動不変（FAQの recharts が使う生 `--chart-*` 変数とWorldMapの `.tooltip` は保持）。

## 見送った項目
- **Partytown（GTM/GAのWorker化）**：Turbopackとの相性・GA計測リスクのため今回見送り。
- **`experimental.optimizeCss`**：Turbopackビルドでは no-op であることを検証で確認したため不採用。
- **framer-motion 軽量化 / Background 軽量化**：サイトのリッチさに関わるため別途慎重に対応予定。

## 検証
- `pnpm check`（lint / typecheck / format:check）通過 ✅
- `pnpm build` 成功 ✅
- 本番サーバで preconnect 反映・フォント preload 3本・CLS 0.013 を確認 ✅
- ⚠️ TBT等のCPU依存スコアはローカル計測環境の負荷で正確に出ないため、**実数値はデプロイプレビューのPageSpeed Insights**で確認推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)