### PR TITLE
feat: add previous PR changes to update history and increase loading animation time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "travel-diary",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "private": true,
   "packageManager": "pnpm@10.27.0",
   "scripts": {

--- a/src/components/common/InitialPreloader.tsx
+++ b/src/components/common/InitialPreloader.tsx
@@ -9,9 +9,9 @@ const EXIT_MS = 1000;
 // エントランス演出を見せる最低表示時間。
 // NOTE: フルスクリーンでコンテンツを隠すため、長くするほど体感速度と
 // LCP を悪化させる。演出は維持しつつ待ち時間は最小限にする。
-const MIN_VISIBLE_MS = 800;
+const MIN_VISIBLE_MS = 1200;
 // load が発火しない等の保険として、最大でこの時間で退場を始める。
-const MAX_VISIBLE_MS = 3000;
+const MAX_VISIBLE_MS = 4500;
 
 /**
  * 初回ロード／リロード時だけ表示するフルスクリーンのスプラッシュ。

--- a/src/components/features/roadmap/UpdateList.tsx
+++ b/src/components/features/roadmap/UpdateList.tsx
@@ -41,6 +41,14 @@ const TYPE_VARIANT: Record<UpdateType, "default" | "secondary" | "outline"> = {
 // 並びは新しい順。package.json の version と先頭エントリを一致させること。
 const UPDATES: UpdateItem[] = [
   {
+    date: "2026.07.02",
+    version: "v4.9.1",
+    title: "コンテンツの補強と読み込み表示の調整",
+    content:
+      "AdSense再審査に向けて、内容が薄かった一部の記事を補強し、リンク切れなどの不具合を修正しました。また、サイト表示時のローディングアニメーションを見られるように、表示時間を少し長く調整しています。",
+    type: "patch",
+  },
+  {
     date: "2026.06.23",
     version: "v4.9.0",
     title: "フッター・404・共有・各種ポリシーを整理し、一部ページを統合",


### PR DESCRIPTION
This PR adds the previous PR changes (AdSense content reinforcement and broken link fixes) to the update history and increases the display time of the loading animation by 1.5 times without slowing down the animation itself.

---
*PR created automatically by Jules for task [11764826913897614831](https://jules.google.com/task/11764826913897614831) started by @tomoki013*